### PR TITLE
Adding converters for Radius.Core/terraformSettings and Radius.Core/bicepSettings

### DIFF
--- a/pkg/corerp/api/v20250801preview/bicepsettings_conversion.go
+++ b/pkg/corerp/api/v20250801preview/bicepsettings_conversion.go
@@ -1,0 +1,185 @@
+/*
+Copyright 2024 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v20250801preview
+
+import (
+	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
+	"github.com/radius-project/radius/pkg/corerp/datamodel"
+	"github.com/radius-project/radius/pkg/to"
+)
+
+// ConvertTo converts from the versioned BicepSettings resource to the datamodel representation.
+func (src *BicepSettingsResource) ConvertTo() (v1.DataModelInterface, error) {
+	converted := &datamodel.BicepSettings_v20250801preview{
+		BaseResource: v1.BaseResource{
+			TrackedResource: v1.TrackedResource{
+				ID:       to.String(src.ID),
+				Name:     to.String(src.Name),
+				Type:     to.String(src.Type),
+				Location: to.String(src.Location),
+				Tags:     to.StringMap(src.Tags),
+			},
+			InternalMetadata: v1.InternalMetadata{
+				UpdatedAPIVersion:      Version,
+				AsyncProvisioningState: toProvisioningStateDataModel(src.Properties.ProvisioningState),
+			},
+		},
+	}
+
+	if src.Properties != nil {
+		converted.Properties = datamodel.BicepSettingsProperties_v20250801preview{
+			Authentication: bicepAuthenticationToDatamodel(src.Properties.Authentication),
+		}
+	}
+
+	return converted, nil
+}
+
+// ConvertFrom converts from the datamodel BicepSettings resource to the versioned representation.
+func (dst *BicepSettingsResource) ConvertFrom(src v1.DataModelInterface) error {
+	bs, ok := src.(*datamodel.BicepSettings_v20250801preview)
+	if !ok {
+		return v1.ErrInvalidModelConversion
+	}
+
+	dst.ID = to.Ptr(bs.ID)
+	dst.Name = to.Ptr(bs.Name)
+	dst.Type = to.Ptr(bs.Type)
+	dst.SystemData = fromSystemDataModel(&bs.SystemData)
+	dst.Location = to.Ptr(bs.Location)
+	dst.Tags = *to.StringMapPtr(bs.Tags)
+	dst.Properties = &BicepSettingsProperties{
+		ProvisioningState: fromProvisioningStateDataModel(bs.InternalMetadata.AsyncProvisioningState),
+		Authentication:    bicepAuthenticationFromDatamodel(bs.Properties.Authentication),
+	}
+
+	return nil
+}
+
+func bicepAuthenticationToDatamodel(src *BicepAuthenticationConfiguration) *datamodel.BicepAuthenticationConfiguration {
+	if src == nil {
+		return nil
+	}
+
+	dst := &datamodel.BicepAuthenticationConfiguration{
+		Registries: map[string]*datamodel.BicepRegistryAuthentication{},
+	}
+
+	for host, auth := range src.Registries {
+		if auth == nil {
+			continue
+		}
+		dst.Registries[host] = &datamodel.BicepRegistryAuthentication{
+			Basic:                 bicepBasicToDatamodel(auth.Basic),
+			AzureWorkloadIdentity: bicepAzureWiToDatamodel(auth.AzureWorkloadIdentity),
+			AwsIrsa:               bicepAwsIrsaToDatamodel(auth.AwsIrsa),
+		}
+	}
+
+	return dst
+}
+
+func bicepAuthenticationFromDatamodel(src *datamodel.BicepAuthenticationConfiguration) *BicepAuthenticationConfiguration {
+	if src == nil {
+		return nil
+	}
+
+	dst := &BicepAuthenticationConfiguration{
+		Registries: map[string]*BicepRegistryAuthentication{},
+	}
+
+	for host, auth := range src.Registries {
+		if auth == nil {
+			continue
+		}
+		dst.Registries[host] = &BicepRegistryAuthentication{
+			Basic:                 bicepBasicFromDatamodel(auth.Basic),
+			AzureWorkloadIdentity: bicepAzureWiFromDatamodel(auth.AzureWorkloadIdentity),
+			AwsIrsa:               bicepAwsIrsaFromDatamodel(auth.AwsIrsa),
+		}
+	}
+
+	return dst
+}
+
+func bicepBasicToDatamodel(src *BicepBasicAuthentication) *datamodel.BicepBasicAuthentication {
+	if src == nil {
+		return nil
+	}
+
+	return &datamodel.BicepBasicAuthentication{
+		Username: to.String(src.Username),
+		Secret:   to.String(src.Secret),
+	}
+}
+
+func bicepBasicFromDatamodel(src *datamodel.BicepBasicAuthentication) *BicepBasicAuthentication {
+	if src == nil {
+		return nil
+	}
+
+	return &BicepBasicAuthentication{
+		Username: to.Ptr(src.Username),
+		Secret:   to.Ptr(src.Secret),
+	}
+}
+
+func bicepAzureWiToDatamodel(src *BicepAzureWorkloadIdentityAuthentication) *datamodel.BicepAzureWorkloadIdentityAuthentication {
+	if src == nil {
+		return nil
+	}
+
+	return &datamodel.BicepAzureWorkloadIdentityAuthentication{
+		ClientID: to.String(src.ClientID),
+		TenantID: to.String(src.TenantID),
+		Secret:   to.String(src.Secret),
+	}
+}
+
+func bicepAzureWiFromDatamodel(src *datamodel.BicepAzureWorkloadIdentityAuthentication) *BicepAzureWorkloadIdentityAuthentication {
+	if src == nil {
+		return nil
+	}
+
+	return &BicepAzureWorkloadIdentityAuthentication{
+		ClientID: to.Ptr(src.ClientID),
+		TenantID: to.Ptr(src.TenantID),
+		Secret:   to.Ptr(src.Secret),
+	}
+}
+
+func bicepAwsIrsaToDatamodel(src *BicepAwsIrsaAuthentication) *datamodel.BicepAwsIrsaAuthentication {
+	if src == nil {
+		return nil
+	}
+
+	return &datamodel.BicepAwsIrsaAuthentication{
+		RoleArn: to.String(src.RoleArn),
+		Secret:  to.String(src.Secret),
+	}
+}
+
+func bicepAwsIrsaFromDatamodel(src *datamodel.BicepAwsIrsaAuthentication) *BicepAwsIrsaAuthentication {
+	if src == nil {
+		return nil
+	}
+
+	return &BicepAwsIrsaAuthentication{
+		RoleArn: to.Ptr(src.RoleArn),
+		Secret:  to.Ptr(src.Secret),
+	}
+}

--- a/pkg/corerp/api/v20250801preview/bicepsettings_conversion_test.go
+++ b/pkg/corerp/api/v20250801preview/bicepsettings_conversion_test.go
@@ -1,0 +1,146 @@
+/*
+Copyright 2024 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v20250801preview
+
+import (
+	"testing"
+
+	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
+	"github.com/radius-project/radius/pkg/corerp/datamodel"
+	"github.com/radius-project/radius/pkg/to"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBicepSettingsConvertFromDatamodel(t *testing.T) {
+	dm := &datamodel.BicepSettings_v20250801preview{
+		BaseResource: v1.BaseResource{
+			TrackedResource: v1.TrackedResource{
+				ID:       "/planes/radius/local/providers/Radius.Core/bicepSettings/registry-auth",
+				Name:     "registry-auth",
+				Type:     datamodel.BicepSettingsResourceType_v20250801preview,
+				Location: "radius-westus",
+				Tags: map[string]string{
+					"env": "test",
+				},
+			},
+			InternalMetadata: v1.InternalMetadata{
+				AsyncProvisioningState: v1.ProvisioningStateSucceeded,
+			},
+		},
+		Properties: datamodel.BicepSettingsProperties_v20250801preview{
+			Authentication: &datamodel.BicepAuthenticationConfiguration{
+				Registries: map[string]*datamodel.BicepRegistryAuthentication{
+					"bicep.azurecr.io": {
+						Basic: &datamodel.BicepBasicAuthentication{
+							Username: "user",
+							Secret:   "/planes/radius/local/providers/Radius.Security/secrets/basic-secret",
+						},
+					},
+					"modules.aws.corp.example.com": {
+						AwsIrsa: &datamodel.BicepAwsIrsaAuthentication{
+							RoleArn: "arn:aws:iam::123456789012:role/RadiusBicepModules",
+							Secret:  "/planes/radius/local/providers/Radius.Security/secrets/aws-secret",
+						},
+					},
+					"internal.corp.example.com": {
+						AzureWorkloadIdentity: &datamodel.BicepAzureWorkloadIdentityAuthentication{
+							ClientID: "client-id",
+							TenantID: "tenant-id",
+							Secret:   "/planes/radius/local/providers/Radius.Security/secrets/wi-secret",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	versioned := &BicepSettingsResource{}
+	require.NoError(t, versioned.ConvertFrom(dm))
+
+	assert.Equal(t, dm.ID, to.String(versioned.ID))
+	assert.Equal(t, dm.Name, to.String(versioned.Name))
+	assert.Equal(t, dm.Type, to.String(versioned.Type))
+	assert.Equal(t, dm.Location, to.String(versioned.Location))
+	require.NotNil(t, versioned.Properties)
+	require.NotNil(t, versioned.Properties.Authentication)
+	require.NotNil(t, versioned.Properties.Authentication.Registries["bicep.azurecr.io"])
+	require.NotNil(t, versioned.Properties.Authentication.Registries["bicep.azurecr.io"].Basic)
+	assert.Equal(t, dm.Properties.Authentication.Registries["bicep.azurecr.io"].Basic.Username, to.String(versioned.Properties.Authentication.Registries["bicep.azurecr.io"].Basic.Username))
+	assert.Equal(t, dm.Properties.Authentication.Registries["bicep.azurecr.io"].Basic.Secret, to.String(versioned.Properties.Authentication.Registries["bicep.azurecr.io"].Basic.Secret))
+	require.NotNil(t, versioned.Properties.Authentication.Registries["modules.aws.corp.example.com"].AwsIrsa)
+	assert.Equal(t, dm.Properties.Authentication.Registries["modules.aws.corp.example.com"].AwsIrsa.RoleArn, to.String(versioned.Properties.Authentication.Registries["modules.aws.corp.example.com"].AwsIrsa.RoleArn))
+	require.NotNil(t, versioned.Properties.Authentication.Registries["internal.corp.example.com"].AzureWorkloadIdentity)
+	assert.Equal(t, dm.Properties.Authentication.Registries["internal.corp.example.com"].AzureWorkloadIdentity.ClientID, to.String(versioned.Properties.Authentication.Registries["internal.corp.example.com"].AzureWorkloadIdentity.ClientID))
+}
+
+func TestBicepSettingsConvertToDatamodel(t *testing.T) {
+	versioned := &BicepSettingsResource{
+		ID:       to.Ptr("/planes/radius/local/providers/Radius.Core/bicepSettings/registry-auth"),
+		Name:     to.Ptr("registry-auth"),
+		Type:     to.Ptr("Radius.Core/bicepSettings"),
+		Location: to.Ptr("radius-westus"),
+		Tags: map[string]*string{
+			"env": to.Ptr("test"),
+		},
+		Properties: &BicepSettingsProperties{
+			Authentication: &BicepAuthenticationConfiguration{
+				Registries: map[string]*BicepRegistryAuthentication{
+					"bicep.azurecr.io": {
+						Basic: &BicepBasicAuthentication{
+							Username: to.Ptr("user"),
+							Secret:   to.Ptr("/planes/radius/local/providers/Radius.Security/secrets/basic-secret"),
+						},
+					},
+					"modules.aws.corp.example.com": {
+						AwsIrsa: &BicepAwsIrsaAuthentication{
+							RoleArn: to.Ptr("arn:aws:iam::123456789012:role/RadiusBicepModules"),
+							Secret:  to.Ptr("/planes/radius/local/providers/Radius.Security/secrets/aws-secret"),
+						},
+					},
+					"internal.corp.example.com": {
+						AzureWorkloadIdentity: &BicepAzureWorkloadIdentityAuthentication{
+							ClientID: to.Ptr("client-id"),
+							TenantID: to.Ptr("tenant-id"),
+							Secret:   to.Ptr("/planes/radius/local/providers/Radius.Security/secrets/wi-secret"),
+						},
+					},
+				},
+			},
+			ProvisioningState: to.Ptr(ProvisioningStateSucceeded),
+		},
+	}
+
+	dmInterface, err := versioned.ConvertTo()
+	require.NoError(t, err)
+
+	dm := dmInterface.(*datamodel.BicepSettings_v20250801preview)
+	assert.Equal(t, to.String(versioned.ID), dm.ID)
+	assert.Equal(t, to.String(versioned.Name), dm.Name)
+	assert.Equal(t, to.String(versioned.Type), dm.Type)
+	assert.Equal(t, to.String(versioned.Location), dm.Location)
+	assert.Equal(t, to.StringMap(versioned.Tags), dm.Tags)
+	require.NotNil(t, dm.Properties.Authentication)
+	require.NotNil(t, dm.Properties.Authentication.Registries["bicep.azurecr.io"])
+	assert.Equal(t, "user", dm.Properties.Authentication.Registries["bicep.azurecr.io"].Basic.Username)
+	assert.Equal(t, "/planes/radius/local/providers/Radius.Security/secrets/basic-secret", dm.Properties.Authentication.Registries["bicep.azurecr.io"].Basic.Secret)
+	require.NotNil(t, dm.Properties.Authentication.Registries["modules.aws.corp.example.com"].AwsIrsa)
+	assert.Equal(t, "arn:aws:iam::123456789012:role/RadiusBicepModules", dm.Properties.Authentication.Registries["modules.aws.corp.example.com"].AwsIrsa.RoleArn)
+	require.NotNil(t, dm.Properties.Authentication.Registries["internal.corp.example.com"].AzureWorkloadIdentity)
+	assert.Equal(t, "client-id", dm.Properties.Authentication.Registries["internal.corp.example.com"].AzureWorkloadIdentity.ClientID)
+	assert.Equal(t, v1.ProvisioningStateSucceeded, dm.InternalMetadata.AsyncProvisioningState)
+}

--- a/pkg/corerp/api/v20250801preview/terraformsettings_conversion.go
+++ b/pkg/corerp/api/v20250801preview/terraformsettings_conversion.go
@@ -1,0 +1,288 @@
+/*
+Copyright 2024 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v20250801preview
+
+import (
+	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
+	"github.com/radius-project/radius/pkg/corerp/datamodel"
+	"github.com/radius-project/radius/pkg/to"
+)
+
+// ConvertTo converts from the versioned TerraformSettings resource to the datamodel representation.
+func (src *TerraformSettingsResource) ConvertTo() (v1.DataModelInterface, error) {
+	converted := &datamodel.TerraformSettings_v20250801preview{
+		BaseResource: v1.BaseResource{
+			TrackedResource: v1.TrackedResource{
+				ID:       to.String(src.ID),
+				Name:     to.String(src.Name),
+				Type:     to.String(src.Type),
+				Location: to.String(src.Location),
+				Tags:     to.StringMap(src.Tags),
+			},
+			InternalMetadata: v1.InternalMetadata{
+				UpdatedAPIVersion:      Version,
+				AsyncProvisioningState: toProvisioningStateDataModel(src.Properties.ProvisioningState),
+			},
+		},
+	}
+
+	if src.Properties != nil {
+		converted.Properties = datamodel.TerraformSettingsProperties_v20250801preview{
+			TerraformRC: terraformCliConfigurationToDatamodel(src.Properties.Terraformrc),
+			Backend:     terraformBackendToDatamodel(src.Properties.Backend),
+			Env:         to.StringMap(src.Properties.Env),
+			Logging:     terraformLoggingToDatamodel(src.Properties.Logging),
+		}
+	}
+
+	return converted, nil
+}
+
+// ConvertFrom converts from the datamodel TerraformSettings resource to the versioned representation.
+func (dst *TerraformSettingsResource) ConvertFrom(src v1.DataModelInterface) error {
+	ts, ok := src.(*datamodel.TerraformSettings_v20250801preview)
+	if !ok {
+		return v1.ErrInvalidModelConversion
+	}
+
+	dst.ID = to.Ptr(ts.ID)
+	dst.Name = to.Ptr(ts.Name)
+	dst.Type = to.Ptr(ts.Type)
+	dst.SystemData = fromSystemDataModel(&ts.SystemData)
+	dst.Location = to.Ptr(ts.Location)
+	dst.Tags = *to.StringMapPtr(ts.Tags)
+	dst.Properties = &TerraformSettingsProperties{
+		Terraformrc: terraformCliConfigurationFromDatamodel(ts.Properties.TerraformRC),
+		Backend:     terraformBackendFromDatamodel(ts.Properties.Backend),
+		Env:         stringMapToPointerMap(ts.Properties.Env),
+		Logging:     terraformLoggingFromDatamodel(ts.Properties.Logging),
+		ProvisioningState: fromProvisioningStateDataModel(
+			ts.InternalMetadata.AsyncProvisioningState),
+	}
+
+	return nil
+}
+
+func terraformCliConfigurationToDatamodel(src *TerraformCliConfiguration) *datamodel.TerraformCliConfiguration {
+	if src == nil {
+		return nil
+	}
+
+	dst := &datamodel.TerraformCliConfiguration{}
+
+	if src.Credentials != nil {
+		dst.Credentials = make(map[string]*datamodel.TerraformCredentialConfiguration, len(src.Credentials))
+		for host, cfg := range src.Credentials {
+			if cfg == nil {
+				continue
+			}
+			dst.Credentials[host] = &datamodel.TerraformCredentialConfiguration{
+				Secret: to.String(cfg.Secret),
+			}
+		}
+	}
+
+	dst.ProviderInstallation = terraformProviderInstallationToDatamodel(src.ProviderInstallation)
+
+	return dst
+}
+
+func terraformCliConfigurationFromDatamodel(src *datamodel.TerraformCliConfiguration) *TerraformCliConfiguration {
+	if src == nil {
+		return nil
+	}
+
+	dst := &TerraformCliConfiguration{}
+	if src.Credentials != nil {
+		dst.Credentials = make(map[string]*TerraformCredentialConfiguration, len(src.Credentials))
+		for host, cfg := range src.Credentials {
+			if cfg == nil {
+				continue
+			}
+			dst.Credentials[host] = &TerraformCredentialConfiguration{
+				Secret: to.Ptr(cfg.Secret),
+			}
+		}
+	}
+
+	dst.ProviderInstallation = terraformProviderInstallationFromDatamodel(src.ProviderInstallation)
+	return dst
+}
+
+func terraformProviderInstallationToDatamodel(src *TerraformProviderInstallationConfiguration) *datamodel.TerraformProviderInstallationConfiguration {
+	if src == nil {
+		return nil
+	}
+
+	return &datamodel.TerraformProviderInstallationConfiguration{
+		NetworkMirror: terraformNetworkMirrorToDatamodel(src.NetworkMirror),
+		Direct:        terraformDirectToDatamodel(src.Direct),
+	}
+}
+
+func terraformProviderInstallationFromDatamodel(src *datamodel.TerraformProviderInstallationConfiguration) *TerraformProviderInstallationConfiguration {
+	if src == nil {
+		return nil
+	}
+
+	return &TerraformProviderInstallationConfiguration{
+		NetworkMirror: terraformNetworkMirrorFromDatamodel(src.NetworkMirror),
+		Direct:        terraformDirectFromDatamodel(src.Direct),
+	}
+}
+
+func terraformNetworkMirrorToDatamodel(src *TerraformNetworkMirrorConfiguration) *datamodel.TerraformNetworkMirrorConfiguration {
+	if src == nil {
+		return nil
+	}
+
+	return &datamodel.TerraformNetworkMirrorConfiguration{
+		URL:     to.String(src.URL),
+		Include: to.StringArray(src.Include),
+		Exclude: to.StringArray(src.Exclude),
+	}
+}
+
+func terraformNetworkMirrorFromDatamodel(src *datamodel.TerraformNetworkMirrorConfiguration) *TerraformNetworkMirrorConfiguration {
+	if src == nil {
+		return nil
+	}
+
+	dst := &TerraformNetworkMirrorConfiguration{
+		URL: to.Ptr(src.URL),
+	}
+
+	dst.Include = stringSliceToPtrSlice(src.Include)
+	dst.Exclude = stringSliceToPtrSlice(src.Exclude)
+
+	return dst
+}
+
+func terraformDirectToDatamodel(src *TerraformDirectConfiguration) *datamodel.TerraformDirectConfiguration {
+	if src == nil {
+		return nil
+	}
+
+	return &datamodel.TerraformDirectConfiguration{
+		Include: to.StringArray(src.Include),
+		Exclude: to.StringArray(src.Exclude),
+	}
+}
+
+func terraformDirectFromDatamodel(src *datamodel.TerraformDirectConfiguration) *TerraformDirectConfiguration {
+	if src == nil {
+		return nil
+	}
+
+	return &TerraformDirectConfiguration{
+		Include: stringSliceToPtrSlice(src.Include),
+		Exclude: stringSliceToPtrSlice(src.Exclude),
+	}
+}
+
+func terraformBackendToDatamodel(src *TerraformBackendConfiguration) *datamodel.TerraformBackendConfiguration {
+	if src == nil {
+		return nil
+	}
+
+	dst := &datamodel.TerraformBackendConfiguration{
+		Type:   to.String(src.Type),
+		Config: map[string]any{},
+	}
+
+	for k, v := range src.Config {
+		dst.Config[k] = v
+	}
+
+	return dst
+}
+
+func terraformBackendFromDatamodel(src *datamodel.TerraformBackendConfiguration) *TerraformBackendConfiguration {
+	if src == nil {
+		return nil
+	}
+
+	dst := &TerraformBackendConfiguration{
+		Type:   to.Ptr(src.Type),
+		Config: map[string]any{},
+	}
+
+	for k, v := range src.Config {
+		dst.Config[k] = v
+	}
+
+	return dst
+}
+
+func terraformLoggingToDatamodel(src *TerraformLoggingConfiguration) *datamodel.TerraformLoggingConfiguration {
+	if src == nil {
+		return nil
+	}
+
+	dst := &datamodel.TerraformLoggingConfiguration{
+		Path: to.String(src.Path),
+	}
+
+	if src.Level != nil {
+		dst.Level = datamodel.TerraformLogLevel(*src.Level)
+	}
+
+	return dst
+}
+
+func terraformLoggingFromDatamodel(src *datamodel.TerraformLoggingConfiguration) *TerraformLoggingConfiguration {
+	if src == nil {
+		return nil
+	}
+
+	dst := &TerraformLoggingConfiguration{
+		Path: to.Ptr(src.Path),
+	}
+
+	if src.Level != "" {
+		level := TerraformLogLevel(src.Level)
+		dst.Level = &level
+	}
+
+	return dst
+}
+
+func stringMapToPointerMap(src map[string]string) map[string]*string {
+	if src == nil {
+		return nil
+	}
+
+	dst := make(map[string]*string, len(src))
+	for k, v := range src {
+		val := v
+		dst[k] = &val
+	}
+	return dst
+}
+
+func stringSliceToPtrSlice(values []string) []*string {
+	if len(values) == 0 {
+		return nil
+	}
+
+	result := make([]*string, len(values))
+	for i, v := range values {
+		valueCopy := v
+		result[i] = &valueCopy
+	}
+	return result
+}

--- a/pkg/corerp/api/v20250801preview/terraformsettings_conversion_test.go
+++ b/pkg/corerp/api/v20250801preview/terraformsettings_conversion_test.go
@@ -1,0 +1,181 @@
+/*
+Copyright 2024 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v20250801preview
+
+import (
+	"testing"
+
+	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
+	"github.com/radius-project/radius/pkg/corerp/datamodel"
+	"github.com/radius-project/radius/pkg/to"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTerraformSettingsConvertFromDatamodel(t *testing.T) {
+	// arrange
+	dm := &datamodel.TerraformSettings_v20250801preview{
+		BaseResource: v1.BaseResource{
+			TrackedResource: v1.TrackedResource{
+				ID:       "/planes/radius/local/providers/Radius.Core/terraformSettings/corp",
+				Name:     "corp",
+				Type:     datamodel.TerraformSettingsResourceType_v20250801preview,
+				Location: "radius-westus",
+				Tags: map[string]string{
+					"env": "prod",
+				},
+			},
+			InternalMetadata: v1.InternalMetadata{
+				AsyncProvisioningState: v1.ProvisioningStateSucceeded,
+			},
+		},
+		Properties: datamodel.TerraformSettingsProperties_v20250801preview{
+			TerraformRC: &datamodel.TerraformCliConfiguration{
+				ProviderInstallation: &datamodel.TerraformProviderInstallationConfiguration{
+					NetworkMirror: &datamodel.TerraformNetworkMirrorConfiguration{
+						URL:     "https://mirror.corp.example.com/providers",
+						Include: []string{"*"},
+						Exclude: []string{"hashicorp/aws"},
+					},
+					Direct: &datamodel.TerraformDirectConfiguration{
+						Exclude: []string{"hashicorp/aws"},
+					},
+				},
+				Credentials: map[string]*datamodel.TerraformCredentialConfiguration{
+					"app.terraform.io": {
+						Secret: "/planes/radius/local/providers/Radius.Security/secrets/tfc-token",
+					},
+				},
+			},
+			Backend: &datamodel.TerraformBackendConfiguration{
+				Type: "kubernetes",
+				Config: map[string]any{
+					"secret_suffix": "corp",
+					"namespace":     "radius-system",
+				},
+			},
+			Env: map[string]string{
+				"TF_LOG": "TRACE",
+			},
+			Logging: &datamodel.TerraformLoggingConfiguration{
+				Level: datamodel.TerraformLogLevel("TRACE"),
+				Path:  "/var/log/terraform/terraform.log",
+			},
+		},
+	}
+
+	versioned := &TerraformSettingsResource{}
+
+	// act
+	err := versioned.ConvertFrom(dm)
+
+	// assert
+	require.NoError(t, err)
+	assert.Equal(t, dm.ID, to.String(versioned.ID))
+	assert.Equal(t, dm.Name, to.String(versioned.Name))
+	assert.Equal(t, dm.Type, to.String(versioned.Type))
+	assert.Equal(t, dm.Location, to.String(versioned.Location))
+	require.NotNil(t, versioned.Properties)
+	require.NotNil(t, versioned.Properties.Terraformrc)
+	require.NotNil(t, versioned.Properties.Terraformrc.ProviderInstallation)
+	assert.Equal(t, dm.Properties.TerraformRC.ProviderInstallation.NetworkMirror.URL, to.String(versioned.Properties.Terraformrc.ProviderInstallation.NetworkMirror.URL))
+	assert.ElementsMatch(t, dm.Properties.TerraformRC.ProviderInstallation.NetworkMirror.Include, to.StringArray(versioned.Properties.Terraformrc.ProviderInstallation.NetworkMirror.Include))
+	assert.ElementsMatch(t, dm.Properties.TerraformRC.ProviderInstallation.NetworkMirror.Exclude, to.StringArray(versioned.Properties.Terraformrc.ProviderInstallation.NetworkMirror.Exclude))
+	require.NotNil(t, versioned.Properties.Terraformrc.Credentials["app.terraform.io"])
+	assert.Equal(t, dm.Properties.TerraformRC.Credentials["app.terraform.io"].Secret, to.String(versioned.Properties.Terraformrc.Credentials["app.terraform.io"].Secret))
+	require.NotNil(t, versioned.Properties.Backend)
+	assert.Equal(t, dm.Properties.Backend.Type, to.String(versioned.Properties.Backend.Type))
+	assert.Equal(t, dm.Properties.Backend.Config, versioned.Properties.Backend.Config)
+	assert.Equal(t, dm.Properties.Env["TF_LOG"], to.String(versioned.Properties.Env["TF_LOG"]))
+	require.NotNil(t, versioned.Properties.Logging)
+	assert.Equal(t, string(dm.Properties.Logging.Level), string(*versioned.Properties.Logging.Level))
+	assert.Equal(t, dm.Properties.Logging.Path, to.String(versioned.Properties.Logging.Path))
+	assert.Equal(t, ProvisioningStateSucceeded, *versioned.Properties.ProvisioningState)
+}
+
+func TestTerraformSettingsConvertToDatamodel(t *testing.T) {
+	// arrange
+	versioned := &TerraformSettingsResource{
+		ID:       to.Ptr("/planes/radius/local/providers/Radius.Core/terraformSettings/corp"),
+		Name:     to.Ptr("corp"),
+		Type:     to.Ptr("Radius.Core/terraformSettings"),
+		Location: to.Ptr("radius-westus"),
+		Tags: map[string]*string{
+			"env": to.Ptr("prod"),
+		},
+		Properties: &TerraformSettingsProperties{
+			Terraformrc: &TerraformCliConfiguration{
+				ProviderInstallation: &TerraformProviderInstallationConfiguration{
+					NetworkMirror: &TerraformNetworkMirrorConfiguration{
+						URL:     to.Ptr("https://mirror.corp.example.com/providers"),
+						Include: to.SliceOfPtrs("*"),
+						Exclude: to.SliceOfPtrs("hashicorp/aws"),
+					},
+					Direct: &TerraformDirectConfiguration{
+						Exclude: to.SliceOfPtrs("hashicorp/aws"),
+					},
+				},
+				Credentials: map[string]*TerraformCredentialConfiguration{
+					"app.terraform.io": {
+						Secret: to.Ptr("/planes/radius/local/providers/Radius.Security/secrets/tfc-token"),
+					},
+				},
+			},
+			Backend: &TerraformBackendConfiguration{
+				Type: to.Ptr("kubernetes"),
+				Config: map[string]any{
+					"secret_suffix": "corp",
+				},
+			},
+			Env: map[string]*string{
+				"TF_LOG": to.Ptr("TRACE"),
+			},
+			Logging: &TerraformLoggingConfiguration{
+				Level: to.Ptr(TerraformLogLevelTrace),
+				Path:  to.Ptr("/var/log/terraform/terraform.log"),
+			},
+			ProvisioningState: to.Ptr(ProvisioningStateSucceeded),
+		},
+	}
+
+	// act
+	dmInterface, err := versioned.ConvertTo()
+
+	// assert
+	require.NoError(t, err)
+	dm := dmInterface.(*datamodel.TerraformSettings_v20250801preview)
+	assert.Equal(t, to.String(versioned.ID), dm.ID)
+	assert.Equal(t, to.String(versioned.Name), dm.Name)
+	assert.Equal(t, to.String(versioned.Type), dm.Type)
+	assert.Equal(t, to.String(versioned.Location), dm.Location)
+	assert.Equal(t, to.StringMap(versioned.Tags), dm.Tags)
+	require.NotNil(t, dm.Properties.TerraformRC)
+	require.NotNil(t, dm.Properties.TerraformRC.ProviderInstallation)
+	assert.Equal(t, to.String(versioned.Properties.Terraformrc.ProviderInstallation.NetworkMirror.URL), dm.Properties.TerraformRC.ProviderInstallation.NetworkMirror.URL)
+	assert.Equal(t, to.StringArray(versioned.Properties.Terraformrc.ProviderInstallation.NetworkMirror.Include), dm.Properties.TerraformRC.ProviderInstallation.NetworkMirror.Include)
+	assert.Equal(t, to.StringArray(versioned.Properties.Terraformrc.ProviderInstallation.NetworkMirror.Exclude), dm.Properties.TerraformRC.ProviderInstallation.NetworkMirror.Exclude)
+	require.NotNil(t, dm.Properties.TerraformRC.Credentials["app.terraform.io"])
+	assert.Equal(t, to.String(versioned.Properties.Terraformrc.Credentials["app.terraform.io"].Secret), dm.Properties.TerraformRC.Credentials["app.terraform.io"].Secret)
+	require.NotNil(t, dm.Properties.Backend)
+	assert.Equal(t, to.String(versioned.Properties.Backend.Type), dm.Properties.Backend.Type)
+	assert.Equal(t, versioned.Properties.Backend.Config, dm.Properties.Backend.Config)
+	assert.Equal(t, to.String(versioned.Properties.Env["TF_LOG"]), dm.Properties.Env["TF_LOG"])
+	require.NotNil(t, dm.Properties.Logging)
+	assert.Equal(t, datamodel.TerraformLogLevel(*versioned.Properties.Logging.Level), dm.Properties.Logging.Level)
+	assert.Equal(t, to.String(versioned.Properties.Logging.Path), dm.Properties.Logging.Path)
+	assert.Equal(t, v1.ProvisioningStateSucceeded, dm.InternalMetadata.AsyncProvisioningState)
+}

--- a/pkg/corerp/datamodel/converter/bicepsettings_converter.go
+++ b/pkg/corerp/datamodel/converter/bicepsettings_converter.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2024 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package converter
+
+import (
+	"encoding/json"
+
+	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
+	v20250801preview "github.com/radius-project/radius/pkg/corerp/api/v20250801preview"
+	"github.com/radius-project/radius/pkg/corerp/datamodel"
+)
+
+// BicepSettingsModelToVersioned converts the datamodel BicepSettings into the versioned API model.
+func BicepSettingsModelToVersioned(model *datamodel.BicepSettings_v20250801preview, version string) (v1.VersionedModelInterface, error) {
+	switch version {
+	case v20250801preview.Version:
+		versioned := &v20250801preview.BicepSettingsResource{}
+		if err := versioned.ConvertFrom(model); err != nil {
+			return nil, err
+		}
+		return versioned, nil
+	default:
+		return nil, v1.ErrUnsupportedAPIVersion
+	}
+}
+
+// BicepSettingsModelFromVersioned converts the versioned payload into the datamodel BicepSettings representation.
+func BicepSettingsModelFromVersioned(content []byte, version string) (*datamodel.BicepSettings_v20250801preview, error) {
+	switch version {
+	case v20250801preview.Version:
+		apiModel := &v20250801preview.BicepSettingsResource{}
+		if err := json.Unmarshal(content, apiModel); err != nil {
+			return nil, err
+		}
+		dm, err := apiModel.ConvertTo()
+		if err != nil {
+			return nil, err
+		}
+		return dm.(*datamodel.BicepSettings_v20250801preview), nil
+	default:
+		return nil, v1.ErrUnsupportedAPIVersion
+	}
+}

--- a/pkg/corerp/datamodel/converter/bicepsettings_converter_test.go
+++ b/pkg/corerp/datamodel/converter/bicepsettings_converter_test.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2024 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package converter
+
+import (
+	"encoding/json"
+	"testing"
+
+	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
+	v20250801preview "github.com/radius-project/radius/pkg/corerp/api/v20250801preview"
+	"github.com/radius-project/radius/pkg/corerp/datamodel"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBicepSettingsModelRoundTrip(t *testing.T) {
+	original := &datamodel.BicepSettings_v20250801preview{
+		BaseResource: v1.BaseResource{
+			TrackedResource: v1.TrackedResource{
+				ID:       "/planes/radius/local/providers/Radius.Core/bicepSettings/registry-auth",
+				Name:     "registry-auth",
+				Type:     datamodel.BicepSettingsResourceType_v20250801preview,
+				Location: "radius-westus",
+			},
+		},
+		Properties: datamodel.BicepSettingsProperties_v20250801preview{
+			Authentication: &datamodel.BicepAuthenticationConfiguration{
+				Registries: map[string]*datamodel.BicepRegistryAuthentication{
+					"bicep.azurecr.io": {
+						Basic: &datamodel.BicepBasicAuthentication{
+							Username: "user",
+							Secret:   "/planes/radius/local/providers/Radius.Security/secrets/basic-secret",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	versioned, err := BicepSettingsModelToVersioned(original, v20250801preview.Version)
+	require.NoError(t, err)
+
+	raw, err := json.Marshal(versioned)
+	require.NoError(t, err)
+
+	converted, err := BicepSettingsModelFromVersioned(raw, v20250801preview.Version)
+	require.NoError(t, err)
+
+	require.Equal(t, original.ID, converted.ID)
+	require.Equal(t, original.Properties.Authentication.Registries["bicep.azurecr.io"].Basic.Secret, converted.Properties.Authentication.Registries["bicep.azurecr.io"].Basic.Secret)
+}

--- a/pkg/corerp/datamodel/converter/terraformsettings_converter.go
+++ b/pkg/corerp/datamodel/converter/terraformsettings_converter.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2024 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package converter
+
+import (
+	"encoding/json"
+
+	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
+	v20250801preview "github.com/radius-project/radius/pkg/corerp/api/v20250801preview"
+	"github.com/radius-project/radius/pkg/corerp/datamodel"
+)
+
+// TerraformSettingsModelToVersioned converts the datamodel TerraformSettings into the versioned API model.
+func TerraformSettingsModelToVersioned(model *datamodel.TerraformSettings_v20250801preview, version string) (v1.VersionedModelInterface, error) {
+	switch version {
+	case v20250801preview.Version:
+		versioned := &v20250801preview.TerraformSettingsResource{}
+		if err := versioned.ConvertFrom(model); err != nil {
+			return nil, err
+		}
+		return versioned, nil
+	default:
+		return nil, v1.ErrUnsupportedAPIVersion
+	}
+}
+
+// TerraformSettingsModelFromVersioned converts the versioned TerraformSettings payload into the datamodel representation.
+func TerraformSettingsModelFromVersioned(content []byte, version string) (*datamodel.TerraformSettings_v20250801preview, error) {
+	switch version {
+	case v20250801preview.Version:
+		apiModel := &v20250801preview.TerraformSettingsResource{}
+		if err := json.Unmarshal(content, apiModel); err != nil {
+			return nil, err
+		}
+		dm, err := apiModel.ConvertTo()
+		if err != nil {
+			return nil, err
+		}
+		return dm.(*datamodel.TerraformSettings_v20250801preview), nil
+	default:
+		return nil, v1.ErrUnsupportedAPIVersion
+	}
+}

--- a/pkg/corerp/datamodel/converter/terraformsettings_converter_test.go
+++ b/pkg/corerp/datamodel/converter/terraformsettings_converter_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2024 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package converter
+
+import (
+	"encoding/json"
+	"testing"
+
+	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
+	v20250801preview "github.com/radius-project/radius/pkg/corerp/api/v20250801preview"
+	"github.com/radius-project/radius/pkg/corerp/datamodel"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTerraformSettingsModelRoundTrip(t *testing.T) {
+	original := &datamodel.TerraformSettings_v20250801preview{
+		BaseResource: v1.BaseResource{
+			TrackedResource: v1.TrackedResource{
+				ID:       "/planes/radius/local/providers/Radius.Core/terraformSettings/sample",
+				Name:     "sample",
+				Type:     datamodel.TerraformSettingsResourceType_v20250801preview,
+				Location: "radius-westus",
+			},
+		},
+		Properties: datamodel.TerraformSettingsProperties_v20250801preview{
+			TerraformRC: &datamodel.TerraformCliConfiguration{
+				ProviderInstallation: &datamodel.TerraformProviderInstallationConfiguration{
+					NetworkMirror: &datamodel.TerraformNetworkMirrorConfiguration{
+						URL: "https://mirror.example.com/providers",
+					},
+				},
+				Credentials: map[string]*datamodel.TerraformCredentialConfiguration{
+					"app.terraform.io": {Secret: "/planes/radius/local/providers/Radius.Security/secrets/token"},
+				},
+			},
+			Backend: &datamodel.TerraformBackendConfiguration{Type: "kubernetes"},
+			Env: map[string]string{
+				"TF_LOG": "INFO",
+			},
+		},
+	}
+
+	versioned, err := TerraformSettingsModelToVersioned(original, v20250801preview.Version)
+	require.NoError(t, err)
+
+	raw, err := json.Marshal(versioned)
+	require.NoError(t, err)
+
+	converted, err := TerraformSettingsModelFromVersioned(raw, v20250801preview.Version)
+	require.NoError(t, err)
+
+	require.Equal(t, original.ID, converted.ID)
+	require.Equal(t, original.Properties.TerraformRC.Credentials["app.terraform.io"].Secret, converted.Properties.TerraformRC.Credentials["app.terraform.io"].Secret)
+	require.Equal(t, original.Properties.Env["TF_LOG"], converted.Properties.Env["TF_LOG"])
+}


### PR DESCRIPTION
# Description

- Add converters and round-trip tests for the new Radius.Core/terraformSettings and Radius.Core/bicepSettings resources, mapping between API models and datamodel.
- Regenerate 2025-08-01-preview artifacts to carry Terraform settings and the richer Bicep auth (basic, Azure Workload Identity, AWS IRSA) schema.

## Type of change
- This pull request adds or changes features of Radius and has an approved issue (issue link required).

Fixes: #issue_number

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

<!--
This checklist uses "TaskRadio" comments to make certain options mutually exclusive.
See: https://github.com/mheap/require-checklist-action?tab=readme-ov-file#radio-groups
For details on how this works and why it's required.
-->

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [x] Yes <!-- TaskRadio schema -->
    - [ ] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [x] Yes <!-- TaskRadio design-pr -->
    - [ ] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [x] Yes <!-- TaskRadio design-review -->
    - [ ] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [x] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [x] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [x] Not applicable <!-- TaskRadio recipes-pr -->